### PR TITLE
Fixed `POST` for protobuf payload in example

### DIFF
--- a/Sources/Server/main.swift
+++ b/Sources/Server/main.swift
@@ -48,6 +48,7 @@ router.post("/v1/book") {
     }
     
     guard let body = request.body else {
+        response.send("If application/octet-stream, this won't work.")
         next()
         return
     }


### PR DESCRIPTION
In your example project, if you were to try to `POST` a protobuf payload in the body, the `BodyParser` doesn't handle `application/octet-stream` and which results in the `RouterRequest` having `nil` for `.body`. My changes determine the `Content-Type` and handle accordingly. If the `Content-Type` is `application/octet-stream`, I gather the body data [in the same way `BodyParser` does](https://github.com/IBM-Swift/Kitura/blob/master/Sources/Kitura/bodyParser/BodyParser.swift#L123-L125) gets the data from the request. If the `Content-Type` is `application/json`, it uses `BodyParser`. 

Ultimately, I'd (and I think you did too) expect that `BodyParser` would correctly store the data as [`.raw(Data)`](https://github.com/IBM-Swift/Kitura/blob/1249f60a27e7f19a55b5569cd3b630312f67b881/Sources/Kitura/bodyParser/ParsedBody.swift#L42) but that is not happening (due to [text-based](https://github.com/IBM-Swift/Kitura/blob/master/Sources/Kitura/bodyParser/BodyParser.swift#L31-L34) content types being handled) and is perhaps cause for another issue. 